### PR TITLE
Use 0-based indexing in the example.

### DIFF
--- a/pages/_howto/howto-beacon-coordinates.md
+++ b/pages/_howto/howto-beacon-coordinates.md
@@ -28,8 +28,8 @@ ACCGTCGA
 ... the exact match for GTC would be
 
 ```
-start: 4,
-end: 7
+start: 3,
+end: 6
 ```
 ... due to interbase coordinates.
 


### PR DESCRIPTION
As far as I can tell, the example is using 1-based indexing, not the 0-based that is defined.
```
 A C C G T C
0 1 2 3 4 5 6
```